### PR TITLE
适配新 bsp 框架

### DIFF
--- a/example/rw007_stm32_port.c
+++ b/example/rw007_stm32_port.c
@@ -36,8 +36,16 @@ static void set_rw007_mode(int mode)
 int wifi_spi_device_init(void)
 {
     char sn_version[32];
+	
+    GPIO_TypeDef *cs_gpiox;
+	uint16_t cs_pin;
+	
+	cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
+	cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
+	
     set_rw007_mode(RW007_SPI_MODE);
-    stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
+	rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
+    // stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
     rt_hw_wifi_init("wspi");
     
     

--- a/example/rw007_stm32_port.c
+++ b/example/rw007_stm32_port.c
@@ -36,15 +36,15 @@ static void set_rw007_mode(int mode)
 int wifi_spi_device_init(void)
 {
     char sn_version[32];
-	
+    
     GPIO_TypeDef *cs_gpiox;
-	uint16_t cs_pin;
-	
-	cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
-	cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
-	
+    uint16_t cs_pin;
+    
+    cs_gpiox = (GPIO_TypeDef *)((rt_base_t)GPIOA + (rt_base_t)(RW007_CS_PIN / 16) * 0x0400UL);
+    cs_pin = (uint16_t)(1 << RW007_CS_PIN % 16);
+    
     set_rw007_mode(RW007_SPI_MODE);
-	rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
+    rt_hw_spi_device_attach(RW007_SPI_BUS_NAME, "wspi", cs_gpiox, cs_pin);
     // stm32_spi_bus_attach_device(RW007_CS_PIN, RW007_SPI_BUS_NAME, "wspi");
     rt_hw_wifi_init("wspi");
     

--- a/src/spi_wifi_rw007.c
+++ b/src/spi_wifi_rw007.c
@@ -604,7 +604,7 @@ rt_err_t rt_hw_wifi_init(const char *spi_device_name)
         struct rt_spi_configuration cfg;
         cfg.data_width = 8;
         cfg.mode = RT_SPI_MODE_0 | RT_SPI_MSB; /* SPI Compatible: Mode 0. */
-        cfg.max_hz = 30 * 1000000;             /* 15M 007 max 30M */
+        cfg.max_hz = 2 * 1000000;             /* 15M 007 max 30M */
         rt_spi_configure(rw007_spi.spi_device, &cfg);
     }
 


### PR DESCRIPTION
[
1.修改 spi 设备注册接口，适配新 stm32 bsp
2.降低 spi 最大波特率为 2M，否则通讯异常（待解决）
]

法师帮忙看下有没问题、是否需要合并到主分支。

